### PR TITLE
feat(bronze): add code and docs for Raw to Bronze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.env
+.databrickscfg
+__pycache__/
+.ipynb_checkpoints/
+.idea/
+.vscode/
+*.DS_Store

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,16 @@
+# Architecture: Raw to Bronze
+
+1) Raw files land in S3 at  
+   `s3://<your-bucket>/raw/licensed_pets/ingestion_date=YYYY-MM-DD/licensed_dogs_and_cats.csv`
+
+2) Databricks reads the CSV with an explicit schema  
+   `_id INT NOT NULL, Year INT, FSA STRING, ANIMAL_TYPE STRING, PRIMARY_BREED STRING`
+
+3) Standardization in Bronze  
+   uppercase and trim text, boolean `FSA_VALID`, `ingestion_ts`, de-duplicate on `_id`
+
+4) Write Bronze as Delta to  
+   `s3://<your-bucket>/bronze/licensed_pets` partitioned by `Year` and `ANIMAL_TYPE`
+
+5) Register the table in Unity Catalog  
+   `pets.core.licensed_pets_bronze` then query with SQL

--- a/docs/bronze.md
+++ b/docs/bronze.md
@@ -1,0 +1,37 @@
+# Bronze snapshot: data checks and counts
+
+Date of run: 2025-09-22  
+Source: City of Toronto Licensed Cats and Dogs
+
+## Row counts
+- Total rows loaded: **173,937**
+- Rows with missing or invalid FSA: **301**  
+- Valid FSA share: ~**99.83%**
+
+## Integrity and quality checks
+- `_id` is non null and de-duplicated
+- `ANIMAL_TYPE` is only in {DOG, CAT}
+- Partition layout created as expected: `Year=2023`, `Year=2024`, `Year=2025` with `ANIMAL_TYPE` subfolders
+
+## Handy queries
+```sql
+-- row count
+SELECT COUNT(*) AS total_rows FROM pets.core.licensed_pets_bronze;
+
+-- FSA validity distribution
+SELECT FSA_VALID, COUNT(*) FROM pets.core.licensed_pets_bronze GROUP BY FSA_VALID;
+
+-- duplicates by id
+SELECT _id, COUNT(*) c
+FROM pets.core.licensed_pets_bronze
+GROUP BY _id HAVING c > 1;
+
+-- counts by year and type
+SELECT Year, ANIMAL_TYPE, COUNT(*) AS petcount
+FROM pets.core.licensed_pets_bronze
+GROUP BY Year, ANIMAL_TYPE
+ORDER BY Year, ANIMAL_TYPE;
+```
+
+## Notes
+Keeping everything in Bronze close to source. For example, Spelling and synonym cleanup for PRIMARY_BREED will be handled in Silver.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,84 @@
+# Runbook: Raw to Bronze
+
+## Purpose
+How to build, validate, and re-run the Bronze Delta table for the Licensed Pets dataset.
+
+## Before you start
+- Workspace is linked to Unity Catalog
+- External Location to S3 is validated
+- You have `USE` and `CREATE TABLE` permisssions on the target catalog and schema
+- Cluster uses a Unity Catalog access mode
+
+## One-time workspace setup
+```sql
+USE CATALOG pets;
+USE SCHEMA core;
+```
+
+## Notebook variables
+```python
+bucket_path = "s3a://<your-bucket>"
+dataset_name = "licensed_pets"
+
+raw_csv_path      = f"{bucket_path}/raw/{dataset_name}/ingestion_date=*/licensed_dogs_and_cats.csv"
+bronze_table_path = f"{bucket_path}/bronze/{dataset_name}"
+```
+
+## Build Bronze
+1. Upload the CSV to `raw/licensed_pets/ingestion_date=YYYY-MM-DD/`.
+2. In the Bronze notebook:
+   - read CSV with the explicit schema
+   - standardize text to uppercase and trim
+   - create `FSA_VALID` boolean and `ingestion_ts` timestamp
+   - drop duplicate `_id`
+   - write Delta to `bronze_table_path` with `mode("overwrite")` and `partitionBy("Year","ANIMAL_TYPE")`
+3. Register the table:
+```sql
+CREATE TABLE IF NOT EXISTS pets.core.licensed_pets_bronze
+USING DELTA
+LOCATION 's3://<your-bucket>/bronze/licensed_pets';
+```
+
+## Validate
+```sql
+-- total rows
+SELECT COUNT(*) FROM pets.core.licensed_pets_bronze;
+
+-- validity distribution
+SELECT FSA_VALID, COUNT(*) FROM pets.core.licensed_pets_bronze GROUP BY FSA_VALID;
+
+-- counts by year and type
+SELECT Year, ANIMAL_TYPE, COUNT(*) AS cnt
+FROM pets.core.licensed_pets_bronze
+GROUP BY Year, ANIMAL_TYPE
+ORDER BY Year, ANIMAL_TYPE;
+```
+
+## Re-run and backfill
+- New drop: change writer to `mode("append")`, re-run the notebook.
+- Full rebuild: use `mode("overwrite")`, re-run.
+- Rebuild a slice: filter the DataFrame to the target `Year` and write only that subset. Example:
+```python
+bronze_df.filter("Year = 2024")   .write.format("delta").mode("overwrite")   .partitionBy("Year","ANIMAL_TYPE")   .save(bronze_table_path)
+```
+
+## Maintenance
+```sql
+-- compact small files when needed
+OPTIMIZE pets.core.licensed_pets_bronze;
+
+-- remove old file versions after a retention window
+VACUUM pets.core.licensed_pets_bronze RETAIN 168 HOURS;
+```
+
+## Cleanup
+- Drop the registered table:
+```sql
+DROP TABLE IF EXISTS pets.core.licensed_pets_bronze;
+```
+- If you also want to remove files, delete the `bronze/licensed_pets` folder in S3.
+
+## Troubleshooting
+- Access denied: check External Location grants and cluster access mode
+- Empty read: confirm the `ingestion_date=...` path matches your wildcard
+- Schema mismatch: ensure CSV header names match the explicit schema.

--- a/notebooks/bronze_build.py
+++ b/notebooks/bronze_build.py
@@ -1,0 +1,84 @@
+# Databricks notebook source
+# DBTITLE 1,Creating a Catalog and Schema
+# MAGIC %sql
+# MAGIC -- Creating a Catalog and Schema
+# MAGIC -- Catalog - "Project Space", Schema - "Folder inside my catalog. Contains tables, views, data assets" 
+# MAGIC CREATE CATALOG IF NOT EXISTS pets COMMENT "Dogs and Cats Proj Catalog";
+# MAGIC GRANT USE CATALOG ON CATALOG pets TO `sayeem.m@hotmail.com`;
+# MAGIC CREATE SCHEMA IF NOT EXISTS pets.core COMMENT "Core tables for licensed pets";
+# MAGIC GRANT USE SCHEMA, CREATE TABLE ON SCHEMA pets.core TO `sayeem.m@hotmail.com`;
+# MAGIC
+# MAGIC -- Ensure I'm writing into the correct Catalog and Schema
+# MAGIC USE CATALOG pets;
+# MAGIC USE SCHEMA core;
+
+# COMMAND ----------
+
+# DBTITLE 1,Defining Paths and Schema
+# Establishing Paths
+bucket_path = "s3a://<your-bucket>"
+dataset_name = "licensed_pets"
+
+raw_csv_path = f"{bucket_path}/raw/{dataset_name}/ingestion_date=*/licensed_dogs_and_cats.csv"
+bronze_table_path = f"{bucket_path}/bronze/{dataset_name}"
+silver_table_path = f"{bucket_path}/silver/{dataset_name}"
+gold_table_path = f"{bucket_path}/gold/{dataset_name}" # Workin on it
+
+# Schema
+from pyspark.sql.types import *
+
+schema = StructType([
+    StructField("_id", IntegerType(), False),
+    StructField("Year", IntegerType(), True),
+    StructField("FSA", StringType(), True),
+    StructField("ANIMAL_TYPE", StringType(), True),
+    StructField("PRIMARY_BREED", StringType(), True)
+])
+
+# COMMAND ----------
+
+# DBTITLE 1,Read Raw CSV and Write Bronze Delta Tables
+from pyspark.sql.functions import *
+
+# Read Raw .csv file
+raw_data_frame = (
+    spark.read
+    .option("header", True)
+    .schema(schema)
+    .csv(raw_csv_path)
+)
+
+# Create Cleaned Bronze data frame
+fsa_pattern = '^[A-Z][0-9][A-Z]$'
+bronze_data_frame = (
+    raw_data_frame
+        # Normalizing text fields - make all upper case, remove white spaces
+        .withColumn("FSA", upper(trim(col("FSA"))))
+        .withColumn("ANIMAL_TYPE", upper(trim(col("ANIMAL_TYPE"))))
+        .withColumn("PRIMARY_BREED", upper(trim(col("PRIMARY_BREED"))))
+        # Create Column FSA_VALID to make sure all FSA's match Canada's A1A pattern, True if yes/ False if no or null
+        .withColumn("FSA_VALID", when(col("FSA").isNotNull() & col("FSA").rlike(fsa_pattern), True).otherwise(False))
+        # Ingestion timestamp
+        .withColumn("ingestion_ts", current_timestamp())
+        .dropDuplicates(["_id"])
+)
+
+# Quick error checking - Fail if any assertions do not pass
+# No records with null identifier "_id"
+assert bronze_data_frame.filter(col("_id").isNull()).isEmpty()
+# Count how many rows are not DOG or CAT
+invalid_count = bronze_data_frame.filter(~col("ANIMAL_TYPE").isin("DOG","CAT")).count()
+# Fail if there are any invalid rows
+assert invalid_count == 0
+
+(
+    bronze_data_frame.write
+        # Choose the Delta Lake table format.
+        .format("delta")
+        # Overwrite any tables which may already be at the specified location, in the future we will use append for an automated load of additional data into the bronze table
+        .mode("overwrite")
+        # Partitioning data into separate subfolders via Year and Animal_Type, other columns would cause over-partitioning
+        .partitionBy("Year", "ANIMAL_TYPE")
+        # Writing the delta table to the path within our bucket which we specified earlier 
+        .save(bronze_table_path)
+)

--- a/sql/register_bronze.sql
+++ b/sql/register_bronze.sql
@@ -1,0 +1,4 @@
+USE CATALOG pets; USE SCHEMA core;
+CREATE TABLE IF NOT EXISTS pets.core.licensed_pets_bronze
+USING DELTA
+LOCATION 's3://<your-bucket>/bronze/licensed_pets';


### PR DESCRIPTION
Added:
1. bronze_build.py in notebooks folder
2. architecture.md, bronze.md and runbook.md in docs folder
3. register_bronze.sql in sql folder

- architecture.md -> describes architecture to go from raw to bronze.
- bronze.md -> a snapshot of data checks and counts.
- runbook.md -> a full runbook showing how to build, validate, and re-run the Bronze Delta table for the Licensed Pets dataset.

note: secrets are not committed :3